### PR TITLE
Update README with note about bash scripts location in Docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,7 @@ docker exec -it ubuntu_container bash
 ```
 
 You can now safely test your scripts within the container environment.
+
+### Note
+
+The bash scripts inside the container can be found in the `/testSrc` folder.


### PR DESCRIPTION
Add a note in the `README.md` about the location of bash scripts inside the container.

* Add a note under the "Using Docker to Safely Test Commands" section.
* Mention that the bash scripts inside the container can be found in the `/testSrc` folder.
